### PR TITLE
Bug fix in IsDevicePluggedIn()

### DIFF
--- a/ScpVBus/bus/busenum.c
+++ b/ScpVBus/bus/busenum.c
@@ -1434,8 +1434,9 @@ NTSTATUS Bus_IsDevicePluggedIn(PVOID Report, PFDO_DEVICE_DATA fdoData, PUCHAR Tr
         {
             Bus_KdPrint(("No devices to report!\n"));
             ExReleaseFastMutex(&fdoData->Mutex);
+			Transfer[0] = 0;
 
-            return STATUS_NO_SUCH_DEVICE;
+            return STATUS_SUCCESS;
         }
 
         // Test that the input id is legitimate

--- a/ScpVBus/bus/busenum.c
+++ b/ScpVBus/bus/busenum.c
@@ -1494,7 +1494,8 @@ NTSTATUS Bus_GetDeviceCreateProcID(PVOID Report, PFDO_DEVICE_DATA fdoData, PULON
         {
             Bus_KdPrint(("No devices to report!\n"));
             ExReleaseFastMutex(&fdoData->Mutex);
-            return STATUS_NO_SUCH_DEVICE;
+			*Transfer = 0;
+            return STATUS_SUCCESS;
         }
 
         // Test that the input id is legitimate

--- a/XOutput/Tester/Tester.cpp
+++ b/XOutput/Tester/Tester.cpp
@@ -24,9 +24,13 @@ int main()
 	result = XOutputGetBusVersion(&ver);
 	printf("XOutputGetBusVersion(): Return 0x%x ; Version=0x%x\n", result, ver);
 
+	BOOL Exist;
+	result = XOutputIsPluggedIn(0, &Exist);
+	result = XOutputIsPluggedIn(7, &Exist);
 
 	result = XOutputUnPlugAll();
 	printf("XOutputUnPlugAll(): Return 0x%x\n", result);
+
 
 	printf("Hit any key toXOutputUnPlugAllForce()\n\n");
 	getchar();
@@ -59,7 +63,9 @@ int main()
 	getchar();
 
 	result = XOutputPlugIn(2);
-	
+	result = XOutputIsPluggedIn(0, &Exist);
+	result = XOutputIsPluggedIn(2, &Exist);
+
 	XINPUT_GAMEPAD 	Gamepad = { 0 };
 	Gamepad.wButtons = 0x1;
 	XOutputSetState(2, &Gamepad);

--- a/XOutput/XOutput.cpp
+++ b/XOutput/XOutput.cpp
@@ -424,7 +424,7 @@ DWORD XOutputIsOwned(DWORD dwUserIndex, PBOOL Owned)
     DWORD trasfered = 0;
 
     // Prepare the User Index for sending
-    buffer[0] = dwUserIndex;
+    buffer[0] = dwUserIndex + 1;
 
     auto retval = DeviceIoControl(g_hScpVBus, IOCTL_BUSENUM_PROC_ID, buffer, _countof(buffer), output, 4, &trasfered, nullptr);
 


### PR DESCRIPTION
Bus_IsDevicePluggedIn() returned error when no devices where installed.
Fix: Set output buffer to 0 and Return STATUS_SUCCESS
